### PR TITLE
Transform options keys to symbols.

### DIFF
--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -8,6 +8,7 @@ require "trilogy/encoding"
 
 class Trilogy
   def initialize(options = {})
+    options = options.transform_keys(&:to_sym)
     options[:port] = options[:port].to_i if options[:port]
     mysql_encoding = options[:encoding] || "utf8mb4"
     encoding = Trilogy::Encoding.find(mysql_encoding)


### PR DESCRIPTION
Before this, any options with a String key (e.g. "host") instead of a Symbol key (e.g. :host) would get silently ignored.

This is surprising in general but in particular, when using Rails and reading the `database.yml` config, they are all String keys so have no affect unless they are transformed before passing to `Trilogy.new`.

This reduces the surprises and ensures the keys are all transformed to Symbols before accessing them.